### PR TITLE
Model local ApiConfig and file uploads

### DIFF
--- a/APIModel.xcodeproj/project.pbxproj
+++ b/APIModel.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		033E79231B7C9FBB008E2A4D /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370B7A81AAF82630085F048 /* Utils.swift */; };
 		0370B7A91AAF82630085F048 /* Api.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370B7921AAF82630085F048 /* Api.swift */; };
 		0370B7AA1AAF82630085F048 /* ApiCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370B7931AAF82630085F048 /* ApiCall.swift */; };
-		0370B7AB1AAF82630085F048 /* ApiConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370B7941AAF82630085F048 /* ApiConfiguration.swift */; };
+		0370B7AB1AAF82630085F048 /* ApiConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370B7941AAF82630085F048 /* ApiConfig.swift */; };
 		0370B7AC1AAF82630085F048 /* ApiId.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370B7951AAF82630085F048 /* ApiId.swift */; };
 		0370B7AD1AAF82630085F048 /* ApiForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370B7961AAF82630085F048 /* ApiForm.swift */; };
 		0370B7AF1AAF82630085F048 /* ArrayTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370B7981AAF82630085F048 /* ArrayTransform.swift */; };
@@ -33,6 +33,8 @@
 		0370B7BE1AAF82630085F048 /* Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370B7A71AAF82630085F048 /* Transform.swift */; };
 		0370B7BF1AAF82630085F048 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370B7A81AAF82630085F048 /* Utils.swift */; };
 		0370B7C01AAF82D50085F048 /* Object+JSONDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0370B7A21AAF82630085F048 /* Object+JSONDictionary.swift */; };
+		038436CB1BB691A400DCCCF0 /* FormDataEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038436CA1BB691A400DCCCF0 /* FormDataEncoding.swift */; settings = {ASSET_TAGS = (); }; };
+		038436CD1BB69D4300DCCCF0 /* ApiConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038436CC1BB69D4300DCCCF0 /* ApiConfigurable.swift */; settings = {ASSET_TAGS = (); }; };
 		038CAB191B17C21D00440808 /* ApiRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038CAB181B17C21D00440808 /* ApiRoutes.swift */; };
 		03E79CEC1BAD5CE9001258A2 /* DefaultTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E79CEA1BAD5CE9001258A2 /* DefaultTransform.swift */; settings = {ASSET_TAGS = (); }; };
 		03E79CED1BAD5CE9001258A2 /* FloatTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E79CEB1BAD5CE9001258A2 /* FloatTransform.swift */; settings = {ASSET_TAGS = (); }; };
@@ -67,7 +69,7 @@
 		0366A4831AAF66ED00506F50 /* ApiModel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ApiModel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0370B7921AAF82630085F048 /* Api.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Api.swift; sourceTree = "<group>"; };
 		0370B7931AAF82630085F048 /* ApiCall.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiCall.swift; sourceTree = "<group>"; };
-		0370B7941AAF82630085F048 /* ApiConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiConfiguration.swift; sourceTree = "<group>"; };
+		0370B7941AAF82630085F048 /* ApiConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiConfig.swift; sourceTree = "<group>"; };
 		0370B7951AAF82630085F048 /* ApiId.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiId.swift; sourceTree = "<group>"; };
 		0370B7961AAF82630085F048 /* ApiForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiForm.swift; sourceTree = "<group>"; };
 		0370B7981AAF82630085F048 /* ArrayTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayTransform.swift; sourceTree = "<group>"; };
@@ -81,6 +83,8 @@
 		0370B7A61AAF82630085F048 /* StringTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTransform.swift; sourceTree = "<group>"; };
 		0370B7A71AAF82630085F048 /* Transform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transform.swift; sourceTree = "<group>"; };
 		0370B7A81AAF82630085F048 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		038436CA1BB691A400DCCCF0 /* FormDataEncoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormDataEncoding.swift; sourceTree = "<group>"; };
+		038436CC1BB69D4300DCCCF0 /* ApiConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiConfigurable.swift; sourceTree = "<group>"; };
 		038CAB181B17C21D00440808 /* ApiRoutes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiRoutes.swift; sourceTree = "<group>"; };
 		03E79CEA1BAD5CE9001258A2 /* DefaultTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultTransform.swift; sourceTree = "<group>"; };
 		03E79CEB1BAD5CE9001258A2 /* FloatTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatTransform.swift; sourceTree = "<group>"; };
@@ -201,6 +205,14 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		038436C91BB6919600DCCCF0 /* Parameter Encodings */ = {
+			isa = PBXGroup;
+			children = (
+				038436CA1BB691A400DCCCF0 /* FormDataEncoding.swift */,
+			);
+			name = "Parameter Encodings";
+			sourceTree = "<group>";
+		};
 		03C60D821AAB5B9A00FE99EA = {
 			isa = PBXGroup;
 			children = (
@@ -220,13 +232,15 @@
 				033E23EB1AF6284E00F1C171 /* ApiRequest.swift */,
 				033E23EE1AF628FF00F1C171 /* ApiResponse.swift */,
 				0370B7931AAF82630085F048 /* ApiCall.swift */,
-				0370B7941AAF82630085F048 /* ApiConfiguration.swift */,
+				0370B7941AAF82630085F048 /* ApiConfig.swift */,
 				0370B7951AAF82630085F048 /* ApiId.swift */,
 				0370B7961AAF82630085F048 /* ApiForm.swift */,
 				038CAB181B17C21D00440808 /* ApiRoutes.swift */,
 				0370B79C1AAF82630085F048 /* ApiTransformable.swift */,
+				038436CC1BB69D4300DCCCF0 /* ApiConfigurable.swift */,
 				033DEF1E1B1CDE1D00266453 /* ApiParser.swift */,
 				0370B7A81AAF82630085F048 /* Utils.swift */,
+				038436C91BB6919600DCCCF0 /* Parameter Encodings */,
 				033DEF201B1CDE2400266453 /* Parsers */,
 				033E23F71AF62C3800F1C171 /* Transforms */,
 				033E23F41AF62AD600F1C171 /* Realm+ApiModel */,
@@ -322,7 +336,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 03C60D861AAB5B9A00FE99EA /* Build configuration list for PBXProject "APIModel" */;
+			buildConfigurationList = 03C60D861AAB5B9A00FE99EA /* Build configuration list for PBXProject "ApiModel" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -416,18 +430,20 @@
 				0370B7B21AAF82630085F048 /* IntTransform.swift in Sources */,
 				033E23F91AF62EB600F1C171 /* README.md in Sources */,
 				03E79CED1BAD5CE9001258A2 /* FloatTransform.swift in Sources */,
+				038436CD1BB69D4300DCCCF0 /* ApiConfigurable.swift in Sources */,
 				0370B7BD1AAF82630085F048 /* StringTransform.swift in Sources */,
 				033DEF221B1CDEBE00266453 /* JSONParser.swift in Sources */,
 				0370B7BE1AAF82630085F048 /* Transform.swift in Sources */,
 				0326C5161AFB7B79005FC057 /* Pluralize.swift in Sources */,
 				0370B7A91AAF82630085F048 /* Api.swift in Sources */,
 				0370B7B51AAF82630085F048 /* NSDateTransform.swift in Sources */,
-				0370B7AB1AAF82630085F048 /* ApiConfiguration.swift in Sources */,
+				0370B7AB1AAF82630085F048 /* ApiConfig.swift in Sources */,
 				038CAB191B17C21D00440808 /* ApiRoutes.swift in Sources */,
 				0370B7BF1AAF82630085F048 /* Utils.swift in Sources */,
 				0370B7AF1AAF82630085F048 /* ArrayTransform.swift in Sources */,
 				6DE1A3261AFB6035002CB25E /* Object+ApiModel.swift in Sources */,
 				0370B7B01AAF82630085F048 /* BoolTransform.swift in Sources */,
+				038436CB1BB691A400DCCCF0 /* FormDataEncoding.swift in Sources */,
 				0370B7AD1AAF82630085F048 /* ApiForm.swift in Sources */,
 				033E23EC1AF6284E00F1C171 /* ApiRequest.swift in Sources */,
 				03E79CEC1BAD5CE9001258A2 /* DefaultTransform.swift in Sources */,
@@ -705,7 +721,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		03C60D861AAB5B9A00FE99EA /* Build configuration list for PBXProject "APIModel" */ = {
+		03C60D861AAB5B9A00FE99EA /* Build configuration list for PBXProject "ApiModel" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				03C60D871AAB5B9A00FE99EA /* Debug */,

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ apiConfig.requestLogging = false
 
 For the most part an API is consistent across endpoints, however in the real world, conventions usually differ wildly. The global configuration is the one set by calling `ApiSingleton.setInstance(API(configuration: apiConfig))`.
 
-To have a model-local configuration your model needs to implement the `ApiConfigurable` protocol, which consists of a single method:
+To have a model-local configuration a model needs to implement the `ApiConfigurable` protocol, which consists of a single method:
 
 ```swift
 public protocol ApiConfigurable {
@@ -132,7 +132,7 @@ public protocol ApiConfigurable {
 }
 ```
 
-Implement the `apiConfig` method, input is the root base configuration and output is the model's config object. The object passed in is a copy of the root configuration, so you are free to modify that object without any side-effects.
+Input is the root base configuration and output is the model's own config object. The object passed in is a copy of the root configuration, so you are free to modify that object without any side-effects.
 
 ```swift
 static func apiConfig(config: ApiConfig) -> ApiConfig {
@@ -158,6 +158,7 @@ ApiForm<Post>.get("/v1/posts.json") { response in
 }
 
 // Other supported methods:
+
 ApiForm<Post>.get(path, parameters: [String:AnyObject]) { response // ...
 ApiForm<Post>.post(path, parameters: [String:AnyObject]) { response // ...
 ApiForm<Post>.put(path, parameters: [String:AnyObject]) { response // ...
@@ -169,6 +170,12 @@ ApiForm<Post>.get(path) { response // ...
 ApiForm<Post>.post(path) { response // ...
 ApiForm<Post>.put(path) { response // ...
 ApiForm<Post>.delete(path) { response // ...
+
+// You can also pass in custom `ApiConfig` into each of the above mentioned methods:
+ApiForm<Post>.get(path, parameters: [String:AnyObject], apiConfig: ApiConfig) { response // ...
+ApiForm<Post>.post(path, parameters: [String:AnyObject], apiConfig: ApiConfig) { response // ...
+ApiForm<Post>.put(path, parameters: [String:AnyObject], apiConfig: ApiConfig) { response // ...
+ApiForm<Post>.delete(path, parameters: [String:AnyObject], apiConfig: ApiConfig) { response // ...
 ```
 
 Most of the time you'll want to use the `ActiveRecord`-style verbs `index/show/create/update` for interacting with a REST API, as described below.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ class Post: Object, ApiTransformable {
     * [Getting started](#getting-started)
     * [Table of Contents](#table-of-contents)
     * [Configuring the API](#configuring-the-api)
+      * [Global and Model-local configurations](#global-and-model-local-configurations)
     * [Interacting with APIs](#interacting-with-apis)
       * [Basic REST verbs](#basic-rest-verbs)
       * [Fetching objects](#fetching-objects)
@@ -118,6 +119,26 @@ If you would like to disable request logging, you can do so by setting `requestL
 ```swift
 apiConfig.requestLogging = false
 ```
+
+### Global and Model-local configurations
+
+For the most part an API is consistent across endpoints, however in the real world, conventions usually differ wildly. The global configuration is the one set by calling `ApiSingleton.setInstance(API(configuration: apiConfig))`.
+
+To have a model-local configuration your model needs to implement the `ApiConfigurable` protocol, which consists of a single method:
+
+```swift
+public protocol ApiConfigurable {
+    static func apiConfig(config: ApiConfig) -> ApiConfig
+}
+```
+
+Implement the `apiConfig` method, input is the root base configuration and output is the model's config object. The object passed in is a copy of the root configuration, so you are free to modify that object without any side-effects.
+
+```swift
+static func apiConfig(config: ApiConfig) -> ApiConfig {
+  config.encoding = ApiRequest.FormDataEncoding
+  return config
+}```
 
 ## Interacting with APIs
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To set it up:
 
 ```
 // Put this somewhere in your AppDelegate or together with other initialization code
-var apiConfig = ApiConfiguration(host: "https://service.io/api/v1/")
+var apiConfig = ApiConfig(host: "https://service.io/api/v1/")
 
 ApiSingleton.setInstance(API(configuration: apiConfig))
 ```
@@ -350,10 +350,10 @@ Some API's wrap all their responses in an "envelope", a container that is generi
 }
 ```
 
-To deal with this gracefully there is a configuration option on the `ApiConfiguration` class called `rootNamespace`. This is a dot-separated path that is traversed for each response. To deal with the above example you would simply:
+To deal with this gracefully there is a configuration option on the `ApiConfig` class called `rootNamespace`. This is a dot-separated path that is traversed for each response. To deal with the above example you would simply:
 
 ```swift
-let config = ApiConfiguration()
+let config = ApiConfig()
 config.rootNamespace = "data"
 ```
 
@@ -376,7 +376,7 @@ It can also be more complex, for example if the envelope looked something like t
 This would then convert into the `rootNamespace`:
 
 ```swift
-let config = ApiConfiguration()
+let config = ApiConfig()
 config.rootNamespace = "JsonResponseEnvelope.SuccessFullJsonResponse.SoapResponseContainer.EnterpriseBeanData"
 ```
 

--- a/Source/Api.swift
+++ b/Source/Api.swift
@@ -14,7 +14,7 @@ public class API {
             if self.config.requestLogging {
                 request.userInfo["requestStartedAt"] = NSDate()
                 
-                //print("ApiModel: \(request.method.rawValue) \(request.path) with params: \(request.parameters) \(request.headers)")
+                print("ApiModel: \(request.method.rawValue) \(request.path) with headers: \(request.headers)")
             }
         }
         
@@ -98,8 +98,6 @@ public class API {
                 response.error = ApiResponseError.ServerError(error)
             }
             response.status = alamofireResponse?.statusCode
-            
-            print("BoDY \(response.responseBody)")
             
             for hook in self.afterRequestHooks {
                 hook(request, response)

--- a/Source/Api.swift
+++ b/Source/Api.swift
@@ -99,6 +99,8 @@ public class API {
             }
             response.status = alamofireResponse?.statusCode
             
+            print("BoDY \(response.responseBody)")
+            
             for hook in self.afterRequestHooks {
                 hook(request, response)
             }

--- a/Source/Api.swift
+++ b/Source/Api.swift
@@ -2,24 +2,24 @@ import Foundation
 import Alamofire
 
 public class API {
-    public var configuration: ApiConfiguration
+    public var config: ApiConfig
     
     public var beforeRequestHooks: [((ApiRequest) -> Void)] = []
     public var afterRequestHooks: [((ApiRequest, ApiResponse) -> Void)] = []
     
-    public init(configuration: ApiConfiguration) {
-        self.configuration = configuration
+    public init(config: ApiConfig) {
+        self.config = config
         
         beforeRequest { request in
-            if self.configuration.requestLogging {
+            if self.config.requestLogging {
                 request.userInfo["requestStartedAt"] = NSDate()
                 
-                print("ApiModel: \(request.method.rawValue) \(request.path) with params: \(request.parameters) \(request.headers)")
+                //print("ApiModel: \(request.method.rawValue) \(request.path) with params: \(request.parameters) \(request.headers)")
             }
         }
         
         afterRequest { request, response in
-            if self.configuration.requestLogging {
+            if self.config.requestLogging {
                 let duration: String
                 if let requestStartedAt = request.userInfo["requestStartedAt"] as? NSDate {
                     let formatter = NSNumberFormatter()
@@ -42,10 +42,22 @@ public class API {
         }
     }
     
-    public func request(method: Alamofire.Method, path: String, parameters: [String: AnyObject] = [:], headers: [String: String] = [:], responseHandler: (ApiResponse?, ApiResponseError?) -> Void) {
-        let configuration = api().configuration
+    public func request(
+        method: Alamofire.Method,
+        path: String,
+        parameters: [String: AnyObject] = [:],
+        headers: [String: String] = [:],
+        apiConfig: ApiConfig,
+        responseHandler: (ApiResponse?, ApiResponseError?) -> Void
+    ) {
+        let parser = apiConfig.parser
         
-        let request = ApiRequest(configuration: configuration, method: method, path: path)
+        let request = ApiRequest(
+            config: apiConfig,
+            method: method,
+            path: path
+        )
+        
         request.parameters = parameters
         request.headers = headers
         
@@ -54,7 +66,7 @@ public class API {
         }
         
         performRequest(request) { response in
-            configuration.parser.parse(response.responseBody ?? "") { parsedResponse in
+            parser.parse(response.responseBody ?? "") { parsedResponse in
                 // if response is either nil or NSNull and the request was not 200 it is an error
                 if (parsedResponse == nil || (parsedResponse as? NSNull) != nil) && !response.isSuccessful {
                     response.error = ApiResponseError.BadRequest(code: response.status ?? 0)
@@ -73,19 +85,25 @@ public class API {
     func performRequest(request: ApiRequest, responseHandler: (ApiResponse) -> Void) {
         let response = ApiResponse(request: request)
         
-        Alamofire.request(request.method, request.url, parameters: request.parameters, encoding: request.encoding, headers: request.headers)
-            .responseString { _, alamofireResponse, result in
-                response.responseBody = result.value
-                if let error = result.error {
-                    response.error = ApiResponseError.ServerError(error)
-                }
-                response.status = alamofireResponse?.statusCode
-                
-                for hook in self.afterRequestHooks {
-                    hook(request, response)
-                }
-                
-                responseHandler(response)
+        Alamofire.request(
+            request.method,
+            request.url,
+            parameters: request.parameters,
+            encoding: request.encoding,
+            headers: request.headers
+        )
+        .responseString { _, alamofireResponse, result in
+            response.responseBody = result.value
+            if let error = result.error {
+                response.error = ApiResponseError.ServerError(error)
+            }
+            response.status = alamofireResponse?.statusCode
+            
+            for hook in self.afterRequestHooks {
+                hook(request, response)
+            }
+            
+            responseHandler(response)
         }
     }
     
@@ -99,7 +117,7 @@ public class API {
 }
 
 public struct ApiSingleton {
-    static var instance: API = API(configuration: ApiConfiguration())
+    static var instance: API = API(config: ApiConfig())
     
     public static func setInstance(apiInstance: API) {
         instance = apiInstance

--- a/Source/ApiConfig.swift
+++ b/Source/ApiConfig.swift
@@ -14,4 +14,17 @@ public class ApiConfig {
         self.init()
         self.host = host
     }
+    
+    public convenience init(apiConfig: ApiConfig) {
+        self.init()
+        self.host = apiConfig.host
+        self.parser = apiConfig.parser
+        self.encoding = apiConfig.encoding
+        self.requestLogging = apiConfig.requestLogging
+        self.rootNamespace = apiConfig.rootNamespace
+    }
+    
+    public func copy() -> ApiConfig {
+        return ApiConfig(apiConfig: self)
+    }
 }

--- a/Source/ApiConfig.swift
+++ b/Source/ApiConfig.swift
@@ -1,6 +1,6 @@
 import Alamofire
 
-public class ApiConfiguration {
+public class ApiConfig {
     public var host: String = ""
     public var parser: ApiParser = JSONParser()
     public var encoding: ParameterEncoding = .URL
@@ -8,7 +8,6 @@ public class ApiConfiguration {
     public var rootNamespace = ""
 
     public required init() {
-
     }
 
     public convenience init(host: String) {

--- a/Source/ApiConfigurable.swift
+++ b/Source/ApiConfigurable.swift
@@ -1,0 +1,3 @@
+public protocol ApiConfigurable {
+    static func apiConfig(config: ApiConfig) -> ApiConfig
+}

--- a/Source/ApiForm.swift
+++ b/Source/ApiForm.swift
@@ -87,7 +87,7 @@ public class ApiForm<ModelType:Object where ModelType:ApiTransformable> {
     
     public static func apiConfigForType() -> ApiConfig {
         if let configurable = ModelType.self as? ApiConfigurable.Type {
-            return configurable.apiConfig(api().config)
+            return configurable.apiConfig(api().config.copy())
         } else {
             return api().config
         }

--- a/Source/ApiForm.swift
+++ b/Source/ApiForm.swift
@@ -53,6 +53,7 @@ public class ApiFormResponse<ModelType:Object where ModelType:ApiTransformable> 
 public class ApiForm<ModelType:Object where ModelType:ApiTransformable> {
     public typealias ResponseCallback = (ApiFormResponse<ModelType>) -> Void
     
+    public var apiConfig: ApiConfig
     public var status: ApiFormModelStatus = .None
     public var errors: [String:[String]] = [:]
     public var model: ModelType
@@ -75,8 +76,21 @@ public class ApiForm<ModelType:Object where ModelType:ApiTransformable> {
         return !errors.isEmpty
     }
     
-    public init(model: ModelType) {
+    public required init(model: ModelType, apiConfig: ApiConfig) {
         self.model = model
+        self.apiConfig = apiConfig
+    }
+    
+    public convenience init(model: ModelType) {
+        self.init(model: model, apiConfig: self.dynamicType.apiConfigForType())
+    }
+    
+    public static func apiConfigForType() -> ApiConfig {
+        if let configurable = ModelType.self as? ApiConfigurable.Type {
+            return configurable.apiConfig(api().config)
+        } else {
+            return api().config
+        }
     }
     
     public func updateFromForm(formParameters: NSDictionary) {
@@ -109,36 +123,57 @@ public class ApiForm<ModelType:Object where ModelType:ApiTransformable> {
     
     // api-model style methods
     
+    public class func performWithMethod(method: Alamofire.Method, path: String, parameters: RequestParameters, apiConfig: ApiConfig, callback: ResponseCallback?) {
+        let call = ApiCall(method: method, path: path, parameters: parameters, namespace: ModelType.apiNamespace())
+        perform(call, apiConfig: apiConfig, callback: callback)
+    }
+    
+    // GET
+    public class func get(path: String, parameters: RequestParameters, apiConfig: ApiConfig, callback: ResponseCallback?) {
+        performWithMethod(.GET, path: path, parameters: parameters, apiConfig: apiConfig, callback: callback)
+    }
+    
     public class func get(path: String, parameters: RequestParameters, callback: ResponseCallback?) {
-        let call = ApiCall(method: .GET, path: path, parameters: parameters, namespace: ModelType.apiNamespace())
-        perform(call, callback: callback)
+        get(path, parameters: parameters, apiConfig: apiConfigForType(), callback: callback)
     }
     
     public class func get(path: String, callback: ResponseCallback?) {
         get(path, parameters: [:], callback: callback)
     }
     
+    // POST
+    public class func post(path: String, parameters: RequestParameters, apiConfig: ApiConfig, callback: ResponseCallback?) {
+        performWithMethod(.POST, path: path, parameters: parameters, apiConfig: apiConfig, callback: callback)
+    }
+    
     public class func post(path: String, parameters: RequestParameters, callback: ResponseCallback?) {
-        let call = ApiCall(method: .POST, path: path, parameters: parameters, namespace: ModelType.apiNamespace())
-        perform(call, callback: callback)
+        post(path, parameters: parameters, apiConfig: apiConfigForType(), callback: callback)
     }
     
     public class func post(path: String, callback: ResponseCallback?) {
         post(path, parameters: [:], callback: callback)
     }
     
+    // DELETE
+    public class func delete(path: String, parameters: RequestParameters, apiConfig: ApiConfig, callback: ResponseCallback?) {
+        performWithMethod(.DELETE, path: path, parameters: parameters, apiConfig: apiConfig, callback: callback)
+    }
+    
     public class func delete(path: String, parameters: RequestParameters, callback: ResponseCallback?) {
-        let call = ApiCall(method: .DELETE, path: path, parameters: parameters, namespace: ModelType.apiNamespace())
-        perform(call, callback: callback)
+        delete(path, parameters: parameters, apiConfig: apiConfigForType(), callback: callback)
     }
     
     public class func delete(path: String, callback: ResponseCallback?) {
         delete(path, parameters: [:], callback: callback)
     }
     
+    // PUT
+    public class func put(path: String, parameters: RequestParameters, apiConfig: ApiConfig, callback: ResponseCallback?) {
+        performWithMethod(.PUT, path: path, parameters: parameters, apiConfig: apiConfig, callback: callback)
+    }
+    
     public class func put(path: String, parameters: RequestParameters, callback: ResponseCallback?) {
-        let call = ApiCall(method: .PUT, path: path, parameters: parameters, namespace: ModelType.apiNamespace())
-        perform(call, callback: callback)
+        put(path, parameters: parameters, apiConfig: apiConfigForType(), callback: callback)
     }
     
     public class func put(path: String, callback: ResponseCallback?) {
@@ -203,42 +238,43 @@ public class ApiForm<ModelType:Object where ModelType:ApiTransformable> {
         }
     }
     
-    public class func perform(call: ApiCall, callback: ResponseCallback?) {
+    public class func perform(call: ApiCall, apiConfig: ApiConfig, callback: ResponseCallback?) {
         api().request(
             call.method,
             path: call.path,
-            parameters: call.parameters
-            ) { data, error in
-                let response = ApiFormResponse<ModelType>()
-                response.rawResponse = data
+            parameters: call.parameters,
+            apiConfig: apiConfig
+        ) { data, error in
+            let response = ApiFormResponse<ModelType>()
+            response.rawResponse = data
+            
+            if let errors = self.errorFromResponse(nil, error: error) {
+                response.errors = errors
+            }
+            
+            if let data: AnyObject = data?.parsedResponse {
+                response.responseData = data as? [String:AnyObject]
                 
-                if let errors = self.errorFromResponse(nil, error: error) {
-                    response.errors = errors
-                }
-                
-                if let data: AnyObject = data?.parsedResponse {
-                    response.responseData = data as? [String:AnyObject]
+                if let responseObject = self.objectFromResponseForNamespace(data, namespace: call.namespace) {
+                    response.responseObject = responseObject
+                    response.object = self.fromApi(responseObject)
                     
-                    if let responseObject = self.objectFromResponseForNamespace(data, namespace: call.namespace) {
-                        response.responseObject = responseObject
-                        response.object = self.fromApi(responseObject)
-                        
-                        if let errors = self.errorFromResponse(responseObject, error: error) {
-                            response.errors = errors
-                        }
-                    } else if let arrayData = self.arrayFromResponseForNamespace(data, namespace: call.namespace) {
-                        response.responseArray = arrayData
-                        response.array = []
-                        
-                        for modelData in arrayData {
-                            if let modelDictionary = modelData as? [String:AnyObject] {
-                                response.array?.append(self.fromApi(modelDictionary))
-                            }
+                    if let errors = self.errorFromResponse(responseObject, error: error) {
+                        response.errors = errors
+                    }
+                } else if let arrayData = self.arrayFromResponseForNamespace(data, namespace: call.namespace) {
+                    response.responseArray = arrayData
+                    response.array = []
+                    
+                    for modelData in arrayData {
+                        if let modelDictionary = modelData as? [String:AnyObject] {
+                            response.array?.append(self.fromApi(modelDictionary))
                         }
                     }
                 }
-                
-                callback?(response)
+            }
+            
+            callback?(response)
         }
     }
     

--- a/Source/ApiRequest.swift
+++ b/Source/ApiRequest.swift
@@ -1,7 +1,7 @@
 import Alamofire
 
 public class ApiRequest {
-    public var configuration: ApiConfiguration
+    public var config: ApiConfig
     public var method: Alamofire.Method
     public var path: String
     public var parameters: [String:AnyObject] = [:]
@@ -9,18 +9,18 @@ public class ApiRequest {
     public var userInfo: [String:AnyObject] = [:]
     
     public var encoding: ParameterEncoding {
-        return configuration.encoding
+        return config.encoding
     }
     
-    public init(configuration: ApiConfiguration, method: Alamofire.Method, path: String) {
-        self.configuration = configuration
+    public init(config: ApiConfig, method: Alamofire.Method, path: String) {
+        self.config = config
         self.method = method
         self.path = path
     }
     
     public var url: String {
         if NSURL(string: path)?.scheme.isEmpty ?? true {
-            return configuration.host + path
+            return config.host + path
         } else {
             return path
         }

--- a/Source/FormDataEncoding.swift
+++ b/Source/FormDataEncoding.swift
@@ -10,11 +10,94 @@ import Foundation
 import Alamofire
 
 func formDataEncoding(request: URLRequestConvertible, parameters: [String: AnyObject]?) -> (NSMutableURLRequest, NSError?) {
-    return (request.URLRequest, nil)
+    let boundary = "Boundary-ERIKSAWESOMEBOUNDARYWIEEEEEEEEEEEEEEEEEEE"
+    
+    let request = request.URLRequest
+    
+    let fullData = NSMutableData()
+    addParametersToData(parameters ?? [:], outputData: fullData, withBoundary: boundary)
+    
+    fullData.appendData("--\r\n".dataUsingEncoding(NSUTF8StringEncoding)!)
+    
+    request.HTTPBody = fullData
+    request.HTTPShouldHandleCookies = true
+    
+    request.setValue("multipart/form-data; boundary=" + boundary, forHTTPHeaderField: "Content-Type")
+    request.setValue(String(fullData.length), forHTTPHeaderField: "Content-Length")
+    
+    return (request, nil)
 }
 
 public extension ApiRequest {
     public static var FormDataEncoding: ParameterEncoding {
         return ParameterEncoding.Custom(formDataEncoding)
     }
+}
+
+func addParametersToData(parameters: [String:AnyObject], outputData: NSMutableData, withBoundary boundary: String, keyPrefix: String = "") {
+    let header = "--\(boundary)".dataUsingEncoding(NSUTF8StringEncoding)!
+    let footer = "--\(boundary)".dataUsingEncoding(NSUTF8StringEncoding)!
+    let sep = "\r\n".dataUsingEncoding(NSUTF8StringEncoding)!
+    
+    for (key, value) in parameters {
+        let formKey: String
+        if keyPrefix.isEmpty {
+            formKey = "\(keyPrefix)\(key)"
+        } else {
+            formKey = "\(keyPrefix)[\(key)]"
+        }
+        
+        if let valueData = value as? NSData {
+            outputData.appendData(sep)
+            outputData.appendData(header)
+            outputData.appendData(sep)
+            
+            outputData.appendData(dataToFormDataField(formKey, data: valueData, boundary: boundary, fileName: "file.jpg", contentType: "image/jpg"))
+            
+            outputData.appendData(footer)
+        } else if let nestedParameters = value as? [String:AnyObject] {
+            addParametersToData(nestedParameters, outputData: outputData, withBoundary: boundary, keyPrefix: formKey)
+        } else if let arrayData = value as? [AnyObject] {
+            
+        } else {
+            outputData.appendData(sep)
+            outputData.appendData(header)
+            outputData.appendData(sep)
+            
+            outputData.appendData(stringToFromDataField(formKey, data: String(value), boundary: boundary))
+            
+            outputData.appendData(footer)
+        }
+    }
+}
+
+func dataToFormDataField(key: String, data: NSData, boundary: String, fileName: String?, contentType: String?) -> NSData {
+    let fullData = NSMutableData()
+    
+    let fileNameField: String
+    if let fileName = fileName {
+        fileNameField = "filename=\"\(fileName)\""
+    } else {
+        fileNameField = ""
+    }
+    
+    let contentTypeField: String
+    if let contentType = contentType {
+        contentTypeField = "Content-Type: \(contentType)\r\n"
+    } else {
+        contentTypeField = ""
+    }
+    
+    let header = "Content-Disposition: form-data; name=\"\(key)\"; \(fileNameField)\r\n" +
+        "\(contentTypeField)\r\n"
+    
+    fullData.appendData(header.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!)
+    fullData.appendData(data)
+    
+    return fullData
+}
+
+func stringToFromDataField(key: String, data: String, boundary: String) -> NSData {
+    let stringData = data.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!
+    return dataToFormDataField(key, data: stringData, boundary: boundary, fileName: nil, contentType: nil)
 }

--- a/Source/FormDataEncoding.swift
+++ b/Source/FormDataEncoding.swift
@@ -1,0 +1,20 @@
+//
+//  FormDataEncoding.swift
+//  ApiModel
+//
+//  Created by Erik Rothoff Andersson on 2015-26-09.
+//
+//
+
+import Foundation
+import Alamofire
+
+func formDataEncoding(request: URLRequestConvertible, parameters: [String: AnyObject]?) -> (NSMutableURLRequest, NSError?) {
+    return (request.URLRequest, nil)
+}
+
+public extension ApiRequest {
+    public static var FormDataEncoding: ParameterEncoding {
+        return ParameterEncoding.Custom(formDataEncoding)
+    }
+}

--- a/Source/Object+ApiModel.swift
+++ b/Source/Object+ApiModel.swift
@@ -5,6 +5,28 @@ extension Object {
     public class func localId() -> ApiId {
         return "APIMODELLOCAL-\(NSUUID().UUIDString)"
     }
+    
+    public var isLocal: Bool {
+        if let pk = self.dynamicType.primaryKey() {
+            if let id = self[pk] as? NSString {
+                return id.rangeOfString("APIMODELLOCAL-").location == 0
+            }
+        }
+        
+        return false
+    }
+    
+    public var unlocalId: ApiId {
+        if isLocal {
+            return ""
+        } else if let
+            pk = self.dynamicType.primaryKey(),
+            id = self[pk] as? ApiId {
+                return id
+        } else {
+            return ""
+        }
+    }
 
     public func isApiSaved() -> Bool {
         if let pk = self.dynamicType.primaryKey() {
@@ -17,32 +39,6 @@ extension Object {
             }
         } else {
             return false
-        }
-    }
-
-    public var isLocal: Bool {
-        get {
-            if let pk = self.dynamicType.primaryKey() {
-                if let id = self[pk] as? NSString {
-                    return id.rangeOfString("APIMODELLOCAL-").location == 0
-                }
-            }
-
-            return false
-        }
-    }
-
-    public var unlocalId: ApiId {
-        get {
-            if isLocal {
-                return ""
-            } else if let
-                pk = self.dynamicType.primaryKey(),
-                id = self[pk] as? ApiId {
-                return id
-            } else {
-                return ""
-            }
         }
     }
 
@@ -90,7 +86,7 @@ extension Object {
     }
 
     public func apiUrlForRoute(resource: String) -> String {
-        return "\(api().configuration.host)\(apiRouteWithReplacements(resource))"
+        return "\(api().config.host)\(apiRouteWithReplacements(resource))"
     }
     
     public func apiUrlForRoute(resource: ApiRoutesAction) -> String {


### PR DESCRIPTION
This branch:
- Renames `ApiConfiguration` to `ApiConfig`. Reasoning: `configuration` is just an overly verbose wording. It does not add clarity
- Creates an `ApiConfigurable` protocol that a model can implement to signify that it wants to configure its own copy of a `ApiConfig`
- Creates a custom Alamofire encoding that is `multipart/form-data`, that can be used for file uploads. Called: `ApiRequest.FormDataEncoding`
- Tweak `ApiForm.get/post/put/delete` methods by adding another parameter, `apiConfig`, to manually send in a configuration on a per-request basis.
- Add most of it to `README.md`

Missing:
- [x] Document the `apiConfig`-parameter to `ApiForm.get/post/put/delete`
- [x] Make sure the `apiConfig(ApiConfig) -> ApiConfig` method actually receives a cloned config

Closes #9 and #4 
