### PR TITLE
Remove time zone offsetting from NSDateTransform, update README to include how to deal with timezones.

### DIFF
--- a/APIModel.xcodeproj/project.pbxproj
+++ b/APIModel.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		038436CB1BB691A400DCCCF0 /* FormDataEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038436CA1BB691A400DCCCF0 /* FormDataEncoding.swift */; };
 		038436CD1BB69D4300DCCCF0 /* ApiConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038436CC1BB69D4300DCCCF0 /* ApiConfigurable.swift */; };
 		038CAB191B17C21D00440808 /* ApiRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038CAB181B17C21D00440808 /* ApiRoutes.swift */; };
+		03B4078E1C3BB57000E46AD3 /* NSDateTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B4078D1C3BB57000E46AD3 /* NSDateTransformTests.swift */; };
 		03E79CEC1BAD5CE9001258A2 /* DefaultTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E79CEA1BAD5CE9001258A2 /* DefaultTransform.swift */; };
 		03E79CED1BAD5CE9001258A2 /* FloatTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E79CEB1BAD5CE9001258A2 /* FloatTransform.swift */; };
 		03E79CEF1BAD5D20001258A2 /* TransformChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E79CEE1BAD5D20001258A2 /* TransformChain.swift */; };
@@ -93,6 +94,7 @@
 		038436CA1BB691A400DCCCF0 /* FormDataEncoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormDataEncoding.swift; sourceTree = "<group>"; };
 		038436CC1BB69D4300DCCCF0 /* ApiConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiConfigurable.swift; sourceTree = "<group>"; };
 		038CAB181B17C21D00440808 /* ApiRoutes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiRoutes.swift; sourceTree = "<group>"; };
+		03B4078D1C3BB57000E46AD3 /* NSDateTransformTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDateTransformTests.swift; sourceTree = "<group>"; };
 		03E79CEA1BAD5CE9001258A2 /* DefaultTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultTransform.swift; sourceTree = "<group>"; };
 		03E79CEB1BAD5CE9001258A2 /* FloatTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatTransform.swift; sourceTree = "<group>"; };
 		03E79CEE1BAD5D20001258A2 /* TransformChain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransformChain.swift; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 				2052AD4E1C4850A900C54C6A /* ApiManagerResponseTests.swift */,
 				033E791B1B7C9F78008E2A4D /* RootNamespaceTests.swift */,
 				03088EE81C36B54200F02288 /* ApiManagerRequestTests.swift */,
+				03B4078C1C3BB55F00E46AD3 /* Transforms */,
 				033E79191B7C9F78008E2A4D /* Supporting Files */,
 			);
 			path = Tests;
@@ -231,6 +234,14 @@
 				038436CA1BB691A400DCCCF0 /* FormDataEncoding.swift */,
 			);
 			name = "Parameter Encodings";
+			sourceTree = "<group>";
+		};
+		03B4078C1C3BB55F00E46AD3 /* Transforms */ = {
+			isa = PBXGroup;
+			children = (
+				03B4078D1C3BB57000E46AD3 /* NSDateTransformTests.swift */,
+			);
+			name = Transforms;
 			sourceTree = "<group>";
 		};
 		03C60D821AAB5B9A00FE99EA = {
@@ -370,7 +381,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 03C60D861AAB5B9A00FE99EA /* Build configuration list for PBXProject "APIModel" */;
+			buildConfigurationList = 03C60D861AAB5B9A00FE99EA /* Build configuration list for PBXProject "ApiModel" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -496,6 +507,7 @@
 				207552BC1C484AD4009D519A /* Post.swift in Sources */,
 				2052AD511C485AB900C54C6A /* ApiFormTests.swift in Sources */,
 				2052AD4F1C4850A900C54C6A /* ApiManagerResponseTests.swift in Sources */,
+				03B4078E1C3BB57000E46AD3 /* NSDateTransformTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -807,7 +819,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		03C60D861AAB5B9A00FE99EA /* Build configuration list for PBXProject "APIModel" */ = {
+		03C60D861AAB5B9A00FE99EA /* Build configuration list for PBXProject "ApiModel" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				03C60D871AAB5B9A00FE99EA /* Debug */,

--- a/Source/NSDateTransform.swift
+++ b/Source/NSDateTransform.swift
@@ -1,34 +1,36 @@
 import Foundation
 
 public class NSDateTransform: Transform {
-    public init() {}
-
+    var dateFormatters: [NSDateFormatter] = []
+    
+    public init() {
+        // ISO 8601 dates with time and zone
+        let iso8601Formatter = NSDateFormatter()
+        iso8601Formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        
+        dateFormatters.append(iso8601Formatter)
+    }
+    
+    public init(dateFormat: String) {
+        let userDefinedDateFormatter = NSDateFormatter()
+        userDefinedDateFormatter.dateFormat = dateFormat
+        
+        dateFormatters.insert(userDefinedDateFormatter, atIndex: 0)
+    }
+    
     public func perform(value: AnyObject?) -> AnyObject? {
         if let dateValue = value as? NSDate {
             return dateValue
         }
 
-        // Rails dates with time and zone
         if let stringValue = value as? String {
-            let dateFormatter = NSDateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-            if let date = dateFormatter.dateFromString("\(stringValue)") {
-                return toLocalTimezone(date)
-            }
-
-            // Standard short dates
-            let simpleDateFormatter = NSDateFormatter()
-            simpleDateFormatter.dateFormat = "yyyy-MM-dd"
-            if let date = simpleDateFormatter.dateFromString("\(stringValue)") {
-                return toLocalTimezone(date)
+            for formatter in dateFormatters {
+                if let date = formatter.dateFromString(stringValue) {
+                    return date
+                }
             }
         }
 
         return nil
-    }
-
-    func toLocalTimezone(date: NSDate) -> NSDate {
-        let seconds = NSTimeInterval(NSTimeZone.localTimeZone().secondsFromGMTForDate(date))
-        return NSDate(timeInterval: seconds, sinceDate: date)
     }
 }

--- a/Tests/NSDateTransformTests.swift
+++ b/Tests/NSDateTransformTests.swift
@@ -1,0 +1,77 @@
+//
+//  NSDateTransformTests.swift
+//  ApiModel
+//
+//  Created by Erik Rothoff Andersson on 2016-05-01.
+//
+//
+
+import XCTest
+import ApiModel
+
+class NSDateTransformTests: XCTestCase {
+    
+    let calendar = NSCalendar(identifier: NSCalendarIdentifierGregorian)!
+    let utcTimeZone = NSTimeZone(name: "Etc/UTC")!
+    let yyyyMMDDDateFormatter = NSDateFormatter()
+    
+    override func setUp() {
+        calendar.timeZone = utcTimeZone
+        yyyyMMDDDateFormatter.dateFormat = "yyyy-MM-dd"
+    }
+    
+    func testISO8601WithoutTimezone() {
+        let transform = NSDateTransform()
+        let res = transform.perform("2015-12-30T12:12:33.000Z") as? NSDate
+        
+        let referenceDateCreator = NSDateComponents()
+        referenceDateCreator.year = 2015
+        referenceDateCreator.month = 12
+        referenceDateCreator.day = 30
+        referenceDateCreator.hour = 12
+        referenceDateCreator.minute = 12
+        referenceDateCreator.second = 33
+        
+        let referenceDate = calendar.dateFromComponents(referenceDateCreator)
+        
+        XCTAssertEqualWithAccuracy(res!.timeIntervalSinceReferenceDate, referenceDate!.timeIntervalSinceReferenceDate, accuracy: 0.001)
+    }
+    
+    func testISO8601WithTimezone() {
+        let transform = NSDateTransform()
+        let res = transform.perform("2015-12-30T12:12:33.000-05:00") as? NSDate
+        
+        let referenceDateCreator = NSDateComponents()
+        referenceDateCreator.year = 2015
+        referenceDateCreator.month = 12
+        referenceDateCreator.day = 30
+        referenceDateCreator.hour = 12 + 5 // UTC is + 5 hours
+        referenceDateCreator.minute = 12
+        referenceDateCreator.second = 33
+        
+        let referenceDate = calendar.dateFromComponents(referenceDateCreator)
+        
+        XCTAssertEqualWithAccuracy(res!.timeIntervalSinceReferenceDate, referenceDate!.timeIntervalSinceReferenceDate, accuracy: 0.001)
+    }
+    
+    func testUserDefinedDateFormat() {
+        let transform = NSDateTransform(dateFormat: "yyyy-MM-dd")
+        let res = transform.perform("2015-12-30") as? NSDate
+        
+        let referenceDateCreator = NSDateComponents()
+        referenceDateCreator.year = 2015
+        referenceDateCreator.month = 12
+        referenceDateCreator.day = 30
+        
+        let referenceDate = calendar.dateFromComponents(referenceDateCreator)
+        
+        XCTAssertEqual(yyyyMMDDDateFormatter.stringFromDate(res!), yyyyMMDDDateFormatter.stringFromDate(referenceDate!))
+    }
+    
+    
+    func testInvalidDate() {
+        let transform = NSDateTransform()
+        let res = transform.perform("i am not a date") as? NSDate
+        XCTAssertNil(res)
+    }
+}


### PR DESCRIPTION
@cheneveld this is in reference to the discussion over on https://github.com/erkie/ApiModel/pull/23. After some playing around and checking best practices, I completely removed `toLocalTimezone` because `NSDateFormatter` will by default make sure that it is in the correct time zone.

This is in many ways a breaking change, so I'll make it a major release.

Let me know what you think
