### PR TITLE
Change interface for transforms, to optionally include a realm they use as reference. Write tests for ArrayTransform and ModelTransform.

### DIFF
--- a/APIModel.podspec
+++ b/APIModel.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency "Alamofire", "~> 3.0"
   s.dependency "SwiftyJSON", "~> 2.3.0"
-  s.dependency "RealmSwift", "~> 0.96.3"
+  s.dependency "RealmSwift", "~> 0.97.0"
 end

--- a/APIModel.xcodeproj/project.pbxproj
+++ b/APIModel.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		038436CD1BB69D4300DCCCF0 /* ApiConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038436CC1BB69D4300DCCCF0 /* ApiConfigurable.swift */; };
 		038CAB191B17C21D00440808 /* ApiRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 038CAB181B17C21D00440808 /* ApiRoutes.swift */; };
 		03B4078E1C3BB57000E46AD3 /* NSDateTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B4078D1C3BB57000E46AD3 /* NSDateTransformTests.swift */; };
+		03CA2D901C503F51008F0AF1 /* ModelTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CA2D8F1C503F51008F0AF1 /* ModelTransformTests.swift */; };
+		03CA2D931C50469D008F0AF1 /* ArrayTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CA2D921C50469D008F0AF1 /* ArrayTransformTests.swift */; };
+		03CA2D951C50D3DD008F0AF1 /* Feed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CA2D941C50D3DD008F0AF1 /* Feed.swift */; };
 		03E79CEC1BAD5CE9001258A2 /* DefaultTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E79CEA1BAD5CE9001258A2 /* DefaultTransform.swift */; };
 		03E79CED1BAD5CE9001258A2 /* FloatTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E79CEB1BAD5CE9001258A2 /* FloatTransform.swift */; };
 		03E79CEF1BAD5D20001258A2 /* TransformChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E79CEE1BAD5D20001258A2 /* TransformChain.swift */; };
@@ -96,6 +99,9 @@
 		038436CC1BB69D4300DCCCF0 /* ApiConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiConfigurable.swift; sourceTree = "<group>"; };
 		038CAB181B17C21D00440808 /* ApiRoutes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApiRoutes.swift; sourceTree = "<group>"; };
 		03B4078D1C3BB57000E46AD3 /* NSDateTransformTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDateTransformTests.swift; sourceTree = "<group>"; };
+		03CA2D8F1C503F51008F0AF1 /* ModelTransformTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelTransformTests.swift; sourceTree = "<group>"; };
+		03CA2D921C50469D008F0AF1 /* ArrayTransformTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayTransformTests.swift; sourceTree = "<group>"; };
+		03CA2D941C50D3DD008F0AF1 /* Feed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Feed.swift; sourceTree = "<group>"; };
 		03E79CEA1BAD5CE9001258A2 /* DefaultTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultTransform.swift; sourceTree = "<group>"; };
 		03E79CEB1BAD5CE9001258A2 /* FloatTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatTransform.swift; sourceTree = "<group>"; };
 		03E79CEE1BAD5D20001258A2 /* TransformChain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransformChain.swift; sourceTree = "<group>"; };
@@ -243,6 +249,8 @@
 			isa = PBXGroup;
 			children = (
 				03B4078D1C3BB57000E46AD3 /* NSDateTransformTests.swift */,
+				03CA2D8F1C503F51008F0AF1 /* ModelTransformTests.swift */,
+				03CA2D921C50469D008F0AF1 /* ArrayTransformTests.swift */,
 			);
 			name = Transforms;
 			sourceTree = "<group>";
@@ -288,6 +296,7 @@
 			isa = PBXGroup;
 			children = (
 				207552BB1C484AD4009D519A /* Post.swift */,
+				03CA2D941C50D3DD008F0AF1 /* Feed.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -506,9 +515,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				033E791C1B7C9F78008E2A4D /* RootNamespaceTests.swift in Sources */,
+				03CA2D951C50D3DD008F0AF1 /* Feed.swift in Sources */,
 				033E79231B7C9FBB008E2A4D /* Utils.swift in Sources */,
 				03088EE91C36B54200F02288 /* ApiManagerRequestTests.swift in Sources */,
 				207552BC1C484AD4009D519A /* Post.swift in Sources */,
+				03CA2D931C50469D008F0AF1 /* ArrayTransformTests.swift in Sources */,
+				03CA2D901C503F51008F0AF1 /* ModelTransformTests.swift in Sources */,
 				2052AD511C485AB900C54C6A /* ApiFormTests.swift in Sources */,
 				2052AD4F1C4850A900C54C6A /* ApiManagerResponseTests.swift in Sources */,
 				03B4078E1C3BB57000E46AD3 /* NSDateTransformTests.swift in Sources */,

--- a/Podfile
+++ b/Podfile
@@ -5,8 +5,8 @@ source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
 pod 'Alamofire', '~> 3.0.0'
-pod 'Realm', '~> 0.96.3'
-pod 'RealmSwift', '~> 0.96.3'
+pod 'Realm', '~> 0.97.0'
+pod 'RealmSwift', '~> 0.97.0'
 pod 'SwiftyJSON', '~> 2.3.0'
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,26 +15,26 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (4.7.0)
   - OHHTTPStubs/Swift (4.7.0):
     - OHHTTPStubs/Core
-  - Realm (0.96.3):
-    - Realm/Headers (= 0.96.3)
-  - Realm/Headers (0.96.3)
-  - RealmSwift (0.96.3):
-    - Realm (= 0.96.3)
-  - SwiftyJSON (2.3.0)
+  - Realm (0.97.0):
+    - Realm/Headers (= 0.97.0)
+  - Realm/Headers (0.97.0)
+  - RealmSwift (0.97.0):
+    - Realm (= 0.97.0)
+  - SwiftyJSON (2.3.2)
 
 DEPENDENCIES:
   - Alamofire (~> 3.0.0)
   - OHHTTPStubs
   - OHHTTPStubs/Swift
-  - Realm (~> 0.96.3)
-  - RealmSwift (~> 0.96.3)
+  - Realm (~> 0.97.0)
+  - RealmSwift (~> 0.97.0)
   - SwiftyJSON (~> 2.3.0)
 
 SPEC CHECKSUMS:
   Alamofire: 2457e1b2e6c46bb05c3a598c542b7bfd08893775
   OHHTTPStubs: d2bf6a0f407620d67e75a1d3f12d86a2b1dd15c0
-  Realm: 145d3cdf78a03aee71bde5381ad7e542bd541720
-  RealmSwift: aab84968aad662f61f36473d1aea019f63481505
-  SwiftyJSON: 8d6b61a70277ef2a5d710d372e06e7e2d87fb9e4
+  Realm: b498a6fb9d288b171ff98d0e2d4384c295be8990
+  RealmSwift: d014810dec75c9a3f1a33926d2dabfed855c582c
+  SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
 
 COCOAPODS: 0.39.0

--- a/README.md
+++ b/README.md
@@ -268,8 +268,10 @@ Transforms are used to convert attributes from JSON responses to rich types. The
 `ApiModel` comes with a host of standard transforms. An example is the `IntTransform`:
 
 ```swift
+import RealmSwift
+
 class IntTransform: Transform {
-    func perform(value: AnyObject?) -> AnyObject {
+    func perform(value: AnyObject?, realm: Realm?) -> AnyObject {
         if let asInt = value?.integerValue {
             return asInt
         } else {

--- a/Source/ApiId.swift
+++ b/Source/ApiId.swift
@@ -2,3 +2,14 @@ public typealias ApiId = String
 
 public class ApiIdTransform: StringTransform {
 }
+
+// Since we have decided to store all IDs as strings we need to sometimes convert API responses to IDs.
+public func convertToApiId(anything: AnyObject?) -> ApiId? {
+    if let intId = anything as? Int {
+        return String(intId)
+    } else if let stringId = anything as? String {
+        return stringId
+    } else {
+        return nil
+    }
+}

--- a/Source/ArrayTransform.swift
+++ b/Source/ArrayTransform.swift
@@ -2,20 +2,23 @@ import Foundation
 import RealmSwift
 
 public class ArrayTransform<T: Object where T:ApiModel>: Transform {
+    let nestedModelTransform = ModelTransform<T>()
+    
     public init() {}
 
-    public func perform(value: AnyObject?) -> AnyObject? {
-        if let values = value as? [[String:AnyObject]] {
-            var models: [AnyObject] = []
-            for nestedData in values {
-                let model = T()
-                updateRealmObjectFromDictionaryWithMapping(model, data: nestedData, mapping: T.fromJSONMapping())
-
-                models.append(model)
+    public func perform(value: AnyObject?, realm: Realm?) -> AnyObject? {
+        var models: [T] = []
+        
+        if let values = value as? [AnyObject] {
+            for value in values {
+                if let nestedData = value as? [String:AnyObject],
+                    let model = nestedModelTransform.perform(nestedData, realm: realm) as? T
+                {
+                    models.append(model)
+                }
             }
-            return models
-        } else {
-            return []
         }
+            
+        return models
     }
 }

--- a/Source/BoolTransform.swift
+++ b/Source/BoolTransform.swift
@@ -1,9 +1,10 @@
 import Foundation
+import RealmSwift
 
 public class BoolTransform: Transform {
     public init() {}
 
-    public func perform(value: AnyObject?) -> AnyObject? {
+    public func perform(value: AnyObject?, realm: Realm?) -> AnyObject? {
         if let stringValue = value?.stringValue {
             switch stringValue.lowercaseString {
             case "true": return true

--- a/Source/DefaultTransform.swift
+++ b/Source/DefaultTransform.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RealmSwift
 
 public class DefaultTransform: Transform {
     var defaultValue: AnyObject
@@ -7,7 +8,7 @@ public class DefaultTransform: Transform {
         self.defaultValue = defaultValue
     }
 
-    public func perform(value: AnyObject?) -> AnyObject? {
+    public func perform(value: AnyObject?, realm: Realm?) -> AnyObject? {
         if let value = value {
             return value
         } else {

--- a/Source/DoubleTransform.swift
+++ b/Source/DoubleTransform.swift
@@ -1,9 +1,10 @@
 import Foundation
+import RealmSwift
 
 public class DoubleTransform: Transform {
 	public init() {}
 
-	public func perform(value: AnyObject?) -> AnyObject? {
+	public func perform(value: AnyObject?, realm: Realm?) -> AnyObject? {
 		if let doubleValue = value as? Double {
 			return doubleValue
 		} else if let stringValue = value as? String {

--- a/Source/FloatTransform.swift
+++ b/Source/FloatTransform.swift
@@ -4,7 +4,7 @@ import RealmSwift
 public class FloatTransform: Transform {
     public init() {}
 
-    public func perform(value: AnyObject?) -> AnyObject? {
+    public func perform(value: AnyObject?, realm: Realm?) -> AnyObject? {
         if let asFloat = value?.floatValue {
             return asFloat
         } else {

--- a/Source/IntTransform.swift
+++ b/Source/IntTransform.swift
@@ -1,9 +1,10 @@
 import Foundation
+import RealmSwift
 
 public class IntTransform: Transform {
     public init() {}
 
-    public func perform(value: AnyObject?) -> AnyObject? {
+    public func perform(value: AnyObject?, realm: Realm?) -> AnyObject? {
         if let asInt = value?.integerValue {
             return asInt
         } else {

--- a/Source/ModelTransform.swift
+++ b/Source/ModelTransform.swift
@@ -4,11 +4,28 @@ import RealmSwift
 public class ModelTransform<T: Object where T:ApiModel>: Transform {
     public init() {}
 
-    public func perform(value: AnyObject?) -> AnyObject? {
+    public func perform(value: AnyObject?, realm: Realm?) -> AnyObject? {
         if let value = value as? [String:AnyObject] {
-            let model = T()
+            let model: T
+            
+            if let pk = T.primaryKey(),
+                let pkValue = convertToApiId(value[pk]),
+                let realm = realm,
+                let alreadyPersistedModel = realm.objectForPrimaryKey(T.self, key: pkValue)
+            {
+                model = alreadyPersistedModel
+            } else {
+                model = T()
+            }
+            
             let mapping = T.fromJSONMapping()
-            updateRealmObjectFromDictionaryWithMapping(model, data: value, mapping: mapping)
+            updateRealmObjectFromDictionaryWithMapping(model, data: value, mapping: mapping, originRealm: realm)
+            
+            // If a realm is passed in we need to make sure to add the model in an update: true transaction, otherwise issues might happen down the road if the same object is present multiple times in a large nested response
+            if let realm = realm {
+                realm.add(model, update: true)
+            }
+            
             return model
         } else {
             return T()

--- a/Source/NSDateTransform.swift
+++ b/Source/NSDateTransform.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RealmSwift
 
 let standardTimeZone = NSTimeZone(forSecondsFromGMT: 0)
 
@@ -22,7 +23,7 @@ public class NSDateTransform: Transform {
         dateFormatters.insert(userDefinedDateFormatter, atIndex: 0)
     }
     
-    public func perform(value: AnyObject?) -> AnyObject? {
+    public func perform(value: AnyObject?, realm: Realm?) -> AnyObject? {
         if let dateValue = value as? NSDate {
             return dateValue
         }

--- a/Source/Object+ApiModel.swift
+++ b/Source/Object+ApiModel.swift
@@ -19,24 +19,20 @@ extension Object {
     public var unlocalId: ApiId {
         if isLocal {
             return ""
-        } else if let
-            pk = self.dynamicType.primaryKey(),
-            id = self[pk] as? ApiId {
-                return id
+        } else if let pk = self.dynamicType.primaryKey(),
+            id = convertToApiId(self[pk])
+        {
+            return id
         } else {
             return ""
         }
     }
 
     public func isApiSaved() -> Bool {
-        if let pk = self.dynamicType.primaryKey() {
-            if let idValue = self[pk] as? String {
-                return !idValue.isEmpty
-            } else if let idValue = self[pk] as? Int {
-                return idValue != 0
-            } else {
-                return false
-            }
+        if let pk = self.dynamicType.primaryKey(),
+            let idValue = convertToApiId(self[pk])
+        {
+            return !idValue.isEmpty
         } else {
             return false
         }

--- a/Source/Object+JSONDictionary.swift
+++ b/Source/Object+JSONDictionary.swift
@@ -10,7 +10,7 @@ func camelizedString(string: String) -> String {
     return camelCase
 }
 
-func updateRealmObjectFromDictionaryWithMapping(realmObject: Object, data: [String:AnyObject], mapping: JSONMapping) {
+func updateRealmObjectFromDictionaryWithMapping(realmObject: Object, data: [String:AnyObject], mapping: JSONMapping, originRealm: Realm?) {
     for (var key, value) in data {
         key = camelizedString(key)
         
@@ -21,11 +21,11 @@ func updateRealmObjectFromDictionaryWithMapping(realmObject: Object, data: [Stri
                 optionalValue = nil
             }
             
-            let transformedValue = transform.perform(optionalValue)
+            let transformedValue = transform.perform(optionalValue, realm: originRealm)
             
             if let primaryKey = realmObject.dynamicType.primaryKey(),
-                let modelsPrimaryKey = realmObject[primaryKey] as? ApiId,
-                let responsePrimaryKey = transformedValue as? ApiId
+                let modelsPrimaryKey = convertToApiId(realmObject[primaryKey]),
+                let responsePrimaryKey = convertToApiId(transformedValue)
                 where key == primaryKey && !modelsPrimaryKey.isEmpty
             {
                 if modelsPrimaryKey == responsePrimaryKey {
@@ -55,10 +55,10 @@ extension Object {
     
     public func updateFromDictionary(data: [String:AnyObject]) {
         let mapping = (self as! ApiModel).dynamicType.fromJSONMapping()
-        updateRealmObjectFromDictionaryWithMapping(self, data: data, mapping: mapping)
+        updateRealmObjectFromDictionaryWithMapping(self, data: data, mapping: mapping, originRealm: realm)
     }
     
     public func updateFromDictionaryWithMapping(data: [String:AnyObject], mapping: JSONMapping) {
-        updateRealmObjectFromDictionaryWithMapping(self, data: data, mapping: mapping)
+        updateRealmObjectFromDictionaryWithMapping(self, data: data, mapping: mapping, originRealm: realm)
     }
 }

--- a/Source/PercentageTransform.swift
+++ b/Source/PercentageTransform.swift
@@ -1,9 +1,10 @@
 import Foundation
+import RealmSwift
 
 public class PercentageTransform: Transform {
     public init() {}
 
-    public func perform(value: AnyObject?) -> AnyObject? {
+    public func perform(value: AnyObject?, realm: Realm?) -> AnyObject? {
         if let intValue = value as? Int {
             return Float(intValue) / 100.0
         }

--- a/Source/StringTransform.swift
+++ b/Source/StringTransform.swift
@@ -1,11 +1,14 @@
 import Foundation
+import RealmSwift
 
 public class StringTransform: Transform {
     public init() {}
 
-    public func perform(value: AnyObject?) -> AnyObject? {
+    public func perform(value: AnyObject?, realm: Realm?) -> AnyObject? {
         if value is String {
             return value!
+        } else if let intValue = value as? Int {
+            return String(intValue)
         } else if let stringValue = value?.stringValue {
             return stringValue
         } else {

--- a/Source/Transform.swift
+++ b/Source/Transform.swift
@@ -1,5 +1,6 @@
 import Foundation
+import RealmSwift
 
 public protocol Transform {
-    func perform(value: AnyObject?) -> AnyObject?
+    func perform(value: AnyObject?, realm: Realm?) -> AnyObject?
 }

--- a/Source/TransformChain.swift
+++ b/Source/TransformChain.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RealmSwift
 
 public class TransformChain: Transform {
     public var transforms: [Transform] = []
@@ -7,7 +8,7 @@ public class TransformChain: Transform {
         self.transforms = transforms
     }
 
-    public func perform(value: AnyObject?) -> AnyObject? {
-        return transforms.reduce(value!) { $1.perform($0) }
+    public func perform(value: AnyObject?, realm: Realm?) -> AnyObject? {
+        return transforms.reduce(value!) { $1.perform($0, realm: realm) }
     }
 }

--- a/Tests/ArrayTransformTests.swift
+++ b/Tests/ArrayTransformTests.swift
@@ -1,0 +1,181 @@
+//
+//  ArrayTransformTests.swift
+//  ApiModel
+//
+//  Created by Erik Rothoff Andersson on 2016-20-01.
+//
+//
+
+import XCTest
+import ApiModel
+import RealmSwift
+
+class ArrayTransformTests: XCTestCase {
+    
+    var realm: Realm!
+    var postsTransform: ArrayTransform<Post>!
+    
+    override func setUp() {
+        try! realm = Realm()
+        postsTransform = ArrayTransform<Post>()
+    }
+    
+    override func tearDown() {
+        if let path = realm.configuration.path {
+            try! NSFileManager.defaultManager().removeItemAtPath(path)
+        }
+    }
+    
+    func testACoupleOfConversions() {
+        let response = [
+            [
+                "id": 1,
+                "title": "Taking over the world"
+            ],
+            
+            [
+                "id": 2,
+                "title": "Restoring peace"
+            ]
+        ]
+        
+        let posts = postsTransform.perform(response, realm: nil) as? [Post]
+        
+        XCTAssertEqual(posts?[0].title, "Taking over the world")
+        XCTAssertEqual(posts?[0].id, "1")
+        
+        XCTAssertEqual(posts?[1].title, "Restoring peace")
+        XCTAssertEqual(posts?[1].id, "2")
+    }
+    
+    func testWithOneBadResponse() {
+        let response = [
+            [
+                "id": 1,
+                "title": "Taking over the world"
+            ],
+            
+            "This api sucks"
+        ]
+        
+        let posts = postsTransform.perform(response, realm: nil) as? [Post]
+        
+        XCTAssertEqual(posts?[0].title, "Taking over the world")
+        XCTAssertEqual(posts?[0].id, "1")
+        XCTAssertEqual(posts!.count, 1)
+    }
+    
+    func testWithPersistedObjects() {
+        // Create a couple of persisted objects
+        let persistedPost0 = Post()
+        persistedPost0.id = "1337"
+        persistedPost0.title = "Hello world"
+        
+        let persistedPost1 = Post()
+        persistedPost1.id = "1338"
+        persistedPost1.title = "Bye world"
+        
+        try! realm.write {
+            self.realm.add(persistedPost0, update: true)
+            self.realm.add(persistedPost1, update: true)
+        }
+        
+        let response = [
+            [
+                "id": "1337",
+                "title": "World hello"
+            ],
+            
+            [
+                "id": "1338",
+                "title": "World bye"
+            ]
+        ]
+        
+        try! realm.write {
+            let posts = postsTransform.perform(response, realm: realm) as! [Post]
+            
+            XCTAssertEqual(posts[0].id, "1337")
+            XCTAssertEqual(posts[0].title, "World hello")
+            XCTAssertEqual(persistedPost0.id, "1337")
+            XCTAssertEqual(persistedPost0.title, "World hello")
+            
+            XCTAssertEqual(posts[1].id, "1338")
+            XCTAssertEqual(posts[1].title, "World bye")
+            XCTAssertEqual(persistedPost1.id, "1338")
+            XCTAssertEqual(persistedPost1.title, "World bye")
+        }
+    }
+    
+    func testWithPersistedObjectsButDuplicatesInArrayResponse() {
+        // If an API returns the same object ID twice in an array, it could lead to weird realm crashes
+        // Create a couple of persisted objects
+        let persistedPost0 = Post()
+        persistedPost0.id = "1337"
+        persistedPost0.title = "Hello world"
+        
+        try! realm.write {
+            self.realm.add(persistedPost0, update: true)
+        }
+        
+        let response = [
+            [
+                "id": "1337",
+                "title": "World hello"
+            ],
+            
+            [
+                "id": "1337",
+                "title": "World hello hello"
+            ]
+        ]
+        
+        try! realm.write {
+            let posts = postsTransform.perform(response, realm: realm) as! [Post]
+            
+            XCTAssertEqual(posts[0].id, "1337")
+            XCTAssertEqual(posts[0].title, "World hello hello")
+            XCTAssertEqual(posts[1].id, "1337")
+            XCTAssertEqual(posts[1].title, "World hello hello")
+            XCTAssertEqual(persistedPost0.id, "1337")
+            XCTAssertEqual(persistedPost0.title, "World hello hello")
+        }
+    }
+    
+    func testWithNestedModelsAndDuplicateIDs() {
+        // If an API returns the same object ID twice in an array, it could lead to weird realm crashes
+        // Create a couple of persisted objects
+        let feed = Feed()
+        feed.id = "1"
+        feed.title = "Hello world"
+        
+        try! realm.write {
+            self.realm.add(feed, update: true)
+        }
+        
+        let response = [
+            "id": "1",
+            "title": "Hello world",
+            "posts": [
+                [
+                    "id": "1337",
+                    "title": "World hello"
+                ],
+                
+                [
+                    "id": "1337",
+                    "title": "World hello hello"
+                ]
+            ]
+        ]
+        
+        let feedTransform = ModelTransform<Feed>()
+    
+        try! realm.write {
+            let feedFromResponse = feedTransform.perform(response, realm: feed.realm) as? Feed
+            
+            XCTAssertEqual(feedFromResponse?.posts[0].id, "1337")
+            XCTAssertEqual(feedFromResponse?.posts[0].title, "World hello hello")
+        }
+    }
+}

--- a/Tests/Feed.swift
+++ b/Tests/Feed.swift
@@ -1,0 +1,47 @@
+//
+//  Post.swift
+//  ApiModel
+//
+//  Created by Craig Heneveld on 1/14/16.
+//
+//
+
+import Foundation
+import RealmSwift
+import ApiModel
+
+// A test model for nested models
+class Feed: Object, ApiModel {
+    dynamic var id = ""
+    dynamic var title = ""
+    let posts = List<Post>()
+    
+    override class func primaryKey() -> String {
+        return "id"
+    }
+    
+    class func apiNamespace() -> String {
+        return "feed"
+    }
+    
+    class func apiRoutes() -> ApiRoutes {
+        return ApiRoutes()
+    }
+    
+    class func fromJSONMapping() -> JSONMapping {
+        return [
+            "id": ApiIdTransform(),
+            "title": StringTransform(),
+            "posts": ArrayTransform<Post>()
+        ]
+    }
+    
+    // Define how this object is to be serialized back into a server response format
+    func JSONDictionary() -> [String:AnyObject] {
+        return [
+            "id": id,
+            "title": title,
+            "posts": posts.map { $0.JSONDictionary() }
+        ]
+    }
+}

--- a/Tests/ModelTransformTests.swift
+++ b/Tests/ModelTransformTests.swift
@@ -1,0 +1,65 @@
+//
+//  ModelTransformTests.swift
+//  APIModel
+//
+//  Created by Erik Rothoff Andersson on 2016-20-01.
+//
+//
+
+import XCTest
+import ApiModel
+import RealmSwift
+
+class ModelTransformTests: XCTestCase {
+    
+    var realm: Realm!
+    var postTransform: ModelTransform<Post>!
+    
+    override func setUp() {
+        try! realm = Realm()
+        postTransform = ModelTransform<Post>()
+    }
+    
+    override func tearDown() {
+        if let path = realm.configuration.path {
+            try! NSFileManager.defaultManager().removeItemAtPath(path)
+        }
+    }
+    
+    func testSimpleConversion() {
+        let response = [
+            "id": 1,
+            "title": "Taking over the world"
+        ]
+        
+        let post = postTransform.perform(response, realm: nil) as? Post
+        
+        XCTAssertEqual(post?.title, "Taking over the world")
+        XCTAssertEqual(post?.id, "1")
+    }
+
+    func testConversionIntoPersistedObject() {
+        // Create a persisted object
+        let persistedPost = Post()
+        persistedPost.id = "1337"
+        persistedPost.title = "Hello world"
+        
+        try! realm.write {
+            self.realm.add(persistedPost, update: true)
+        }
+        
+        let response = [
+            "id": "1337",
+            "title": "Hello world, revision II"
+        ]
+        
+        try! realm.write {
+            let otherPost = postTransform.perform(response, realm: realm) as! Post
+            
+            XCTAssertEqual(otherPost.id, "1337")
+            XCTAssertEqual(otherPost.title, "Hello world, revision II")
+            
+            XCTAssertEqual(persistedPost.title, "Hello world, revision II")
+        }
+    }
+}

--- a/Tests/NSDateTransformTests.swift
+++ b/Tests/NSDateTransformTests.swift
@@ -23,7 +23,7 @@ class NSDateTransformTests: XCTestCase {
     
     func testISO8601WithoutTimezone() {
         let transform = NSDateTransform()
-        let res = transform.perform("2015-12-30T12:12:33.000Z") as? NSDate
+        let res = transform.perform("2015-12-30T12:12:33.000Z", realm: nil) as? NSDate
         
         let referenceDateCreator = NSDateComponents()
         referenceDateCreator.timeZone = utcTimeZone
@@ -41,7 +41,7 @@ class NSDateTransformTests: XCTestCase {
     
     func testISO8601WithTimezone() {
         let transform = NSDateTransform()
-        let res = transform.perform("2015-12-30T12:12:33.000-05:00") as? NSDate
+        let res = transform.perform("2015-12-30T12:12:33.000-05:00", realm: nil) as? NSDate
         
         let referenceDateCreator = NSDateComponents()
         referenceDateCreator.timeZone = utcTimeZone
@@ -59,7 +59,7 @@ class NSDateTransformTests: XCTestCase {
     
     func testUserDefinedDateFormat() {
         let transform = NSDateTransform(dateFormat: "yyyy-MM-dd")
-        let res = transform.perform("2015-12-30") as? NSDate
+        let res = transform.perform("2015-12-30", realm: nil) as? NSDate
         
         let referenceDateCreator = NSDateComponents()
         referenceDateCreator.timeZone = utcTimeZone
@@ -75,7 +75,7 @@ class NSDateTransformTests: XCTestCase {
     
     func testInvalidDate() {
         let transform = NSDateTransform()
-        let res = transform.perform("i am not a date") as? NSDate
+        let res = transform.perform("i am not a date", realm: nil) as? NSDate
         XCTAssertNil(res)
     }
 }

--- a/Tests/Post.swift
+++ b/Tests/Post.swift
@@ -15,7 +15,7 @@ class Post: Object, ApiModel {
     dynamic var id = ""
     dynamic var title = ""
     dynamic var contents = ""
-    dynamic lazy var createdAt = NSDate()
+    dynamic var createdAt = NSDate()
     
     override class func primaryKey() -> String {
         return "id"


### PR DESCRIPTION
The story behind this is that realm would crash with an error message 'duplicate entry for primary key' if the same object was present more than once in a large nested response
