### PR TITLE
[WIP] Improve Namespace Support

### DIFF
--- a/Source/ApiCall.swift
+++ b/Source/ApiCall.swift
@@ -7,14 +7,14 @@ public class ApiCall {
     public var method: Alamofire.Method
     public var path: String
     public var parameters: RequestParameters = [:]
-    public var namespace: String = ""
+    public var namespace: ApiNamespace = ApiNamespace(requestNamespace: nil, responseNamespace: nil)
 
     public required init(method: Alamofire.Method, path: String) {
         self.method = method
         self.path = path
     }
     
-    public convenience init(method: Alamofire.Method, path: String, parameters: RequestParameters, namespace: String) {
+    public convenience init(method: Alamofire.Method, path: String, parameters: RequestParameters, namespace: ApiNamespace) {
         self.init(method: method, path: path)
         self.parameters = parameters
         self.namespace = namespace

--- a/Source/ApiModel.swift
+++ b/Source/ApiModel.swift
@@ -3,8 +3,33 @@ import Foundation
 public typealias JSONMapping = [String:Transform]
 
 public protocol ApiModel {
+    
+    static func apiAwareNamespace() -> ApiNamespace
+    
     static func apiNamespace() -> String
+    
     static func apiRoutes() -> ApiRoutes
     static func fromJSONMapping() -> JSONMapping
     func JSONDictionary() -> [String:AnyObject]
+
+}
+
+/*
+ * Needed for backward compatibility
+ */
+public extension ApiModel {
+    
+    static func apiNamespace() -> String {
+        return ""
+    }
+    
+    static func apiAwareNamespace() -> ApiNamespace {
+        var namespace = apiNamespace()
+        if namespace == "" {
+            return ApiNamespace(requestNamespace: nil, responseNamespace: nil)
+        } else {
+            return ApiNamespace(requestNamespace: namespace, responseNamespace: namespace)
+        }
+    }
+ 
 }

--- a/Source/ApiNamespace.swift
+++ b/Source/ApiNamespace.swift
@@ -1,0 +1,11 @@
+public class ApiNamespace {
+    
+    public let requestNamespace: String?
+    public let responseNamespace: String?
+    
+    public required init(requestNamespace: String?, responseNamespace: String?) {
+        self.requestNamespace = requestNamespace
+        self.responseNamespace = responseNamespace
+    }
+    
+}


### PR DESCRIPTION
New object ApiNamespace is introduced to handle parameter namespaces.
This allows more flexible configuration of namespaces for each apiModel using:

```
class func apiAwareNamespace() -> ApiNamespace {
  return ApiNamespace(requestNamespace: "post", responseNamespace: nil)
}
```

Initial solution proposal for #43
